### PR TITLE
pom.xml: include <exec.mainClass>

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,11 +16,7 @@ A sample maven project using BPjs. Clone or fork this project to easily start yo
 * link:src/main/java/il/ac/bgu/cs/bp/samplebpjsproject/HelloWorld.java[Simple "main" class for running `HelloBPjsWorld.js` and emitting its events to stdout].
 
 
-To make the project runnable from the commandline, add this to the `<properties>` node of the `pom.xml` file:
-
-    <exec.mainClass>package.name.goes.here.and.then.ClassName</exec.mainClass>
-
-Then run the application by typing:
+Run the application by typing:
 
     mvn exec:java
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <exec.mainClass>il.ac.bgu.cs.bp.samplebpjsproject.HelloWorld</exec.mainClass>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Including `exec.mainClass` attribute in `pom.xml`, instead of requiring the user to manually add it. Thus, it makes a lower entrance barrier, as it can be immediately run after downloading.